### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Change Log
 
-## [0.5.1] - TBD
+## [0.6.1] - TBD
 ### Added
 - Nothing
+
+
+## [0.6.0] - 2016-10-05
+### Added
+- Log Writer: Added Monolog namespace to default excluded function calls on backtrace
+- Log Writer: Added the possibility to add other namespaces to excluded function calls on backtrace
+- Added the possibility to add multiple `send_callback`s and retrieving it from container
+- Added `CallbackInterface`
+- Added the possibility to specify the `transport` via service name, retrieving it from container  
+- Added `TransportInterface`
+### Changed
+- Changed default logger name to `SentryModule`
+- Required minimum version 1.4 of sentry library
 
 
 ## [0.5.0] - 2016-09-29

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZF2 Sentry Module
+# ZF Sentry Module
 
 [![Build Status](https://api.travis-ci.org/facile-it/sentry-module.svg?branch=master)](https://travis-ci.org/facile-it/sentry-module)
 [![Code Coverage](https://scrutinizer-ci.com/g/facile-it/sentry-module/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/facile-it/sentry-module/?branch=master)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Coverage](https://scrutinizer-ci.com/g/facile-it/sentry-module/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/facile-it/sentry-module/?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/facile-it/sentry-module/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/facile-it/sentry-module/?branch=master)
 
-This module allows to integrate the Raven Sentry Client into Zend Framework 2.
+This module allows integration with Raven Sentry Client into Zend Framework 2/3.
 
 ## Installation
 
@@ -190,4 +190,56 @@ $config = [
 In your layout:
 ```phtml
 <?= $this->headScript() ?>
+```
+
+
+## A complete configuration example
+
+```php
+return [
+    'facile' => [
+        'sentry' => [
+            'client' => [
+                'default' => [
+                    'dsn' => 'http://xxxxxxxxxxxxxxxxxx:xxxxxxxxxxxx@localhost:9000/2',
+                    'options' => [
+                        'auto_log_stacks' => true,
+                        'curl_method' => 'async',
+                        'tags' => [
+                            'php_version' => phpversion(),
+                        ],
+                        'release' => file_exists('REVISION') ? file_get_contents('REVISION') : 'development',
+                        'environment' => getenv('APP_ENV') ?: 'production',
+                        'processorOptions' => [
+                            Raven_SanitizeDataProcessor::class => [
+                                'fields_re' => '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw|cvv2)/i',
+                                'values_re' => '/^(?:\d[ -]*?){13,16}$/',
+                            ],
+                            Facile\SentryModule\Processor\SanitizeDataProcessor::class => [
+                                'fields_re' => '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw|cvv2)/i',
+                                'values_re' => '/^(?:\d[ -]*?){13,16}$/',
+                            ],
+                        ],
+                        'transport' => 'my.transport.service.name',
+                        'send_callback' => [
+                            'my.sendcallback1.service.name',
+                            'my.sendcallback2.service.name',
+                        ],
+                        // Other Raven options
+                    ],
+                    'register_error_handler' => true,
+                    'register_exception_handler' => true,
+                    'register_shutdown_function' => true,
+                    'register_error_listener' => true,
+                ],
+            ],
+            'configuration' => [
+                'raven_javascript_dsn' => 'http://xxxxxxxxxxxxxxxx@localhost:9000/2',
+                'raven_javascript_uri' => 'https://cdn.ravenjs.com/3.7.0/raven.min.js',
+                'inject_raven_javascript' => true,
+            ]
+        ]
+    ]
+];
+
 ```

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require": {
     "php": "^5.6 || ^7.0",
-    "sentry/sentry": "~0.19 || ^1.0",
+    "sentry/sentry": "^1.4",
     "zendframework/zend-stdlib": "^2.7 || ^3.0.1",
     "zendframework/zend-servicemanager": "^2.7 || ^3.0.3",
     "zendframework/zend-mvc": "^2.7 || ^3.0",

--- a/src/SendCallback/CallbackChain.php
+++ b/src/SendCallback/CallbackChain.php
@@ -11,6 +11,7 @@ final class CallbackChain implements CallbackInterface
 
     /**
      * CallbackChain constructor.
+     *
      * @param array|CallbackInterface[] $callbacks
      */
     public function __construct(array $callbacks = [])
@@ -28,6 +29,7 @@ final class CallbackChain implements CallbackInterface
 
     /**
      * @param array $data
+     *
      * @return array
      */
     public function __invoke(array $data)

--- a/src/SendCallback/CallbackChain.php
+++ b/src/SendCallback/CallbackChain.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Facile\SentryModule\SendCallback;
+
+final class CallbackChain implements CallbackInterface
+{
+    /**
+     * @var array|CallbackInterface[]
+     */
+    protected $callbacks = [];
+
+    /**
+     * CallbackChain constructor.
+     * @param array|CallbackInterface[] $callbacks
+     */
+    public function __construct(array $callbacks = [])
+    {
+        $this->callbacks = $callbacks;
+    }
+
+    /**
+     * @param callable $callable
+     */
+    public function addCallback(callable $callable)
+    {
+        $this->callbacks[] = $callable;
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    public function __invoke(array $data)
+    {
+        foreach ($this->callbacks as $callback) {
+            $data = $callback($data);
+        }
+
+        return $data;
+    }
+}

--- a/src/SendCallback/CallbackInterface.php
+++ b/src/SendCallback/CallbackInterface.php
@@ -6,6 +6,7 @@ interface CallbackInterface
 {
     /**
      * @param array $data
+     *
      * @return array
      */
     public function __invoke(array $data);

--- a/src/SendCallback/CallbackInterface.php
+++ b/src/SendCallback/CallbackInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facile\SentryModule\SendCallback;
+
+interface CallbackInterface
+{
+    /**
+     * @param array $data
+     * @return array
+     */
+    public function __invoke(array $data);
+}

--- a/src/Service/ClientFactory.php
+++ b/src/Service/ClientFactory.php
@@ -4,6 +4,7 @@ namespace Facile\SentryModule\Service;
 
 use Facile\SentryModule\Options\ClientOptions;
 use Facile\SentryModule\Processor\SanitizeDataProcessor;
+use Facile\SentryModule\SendCallback\CallbackChain;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -12,6 +13,35 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  */
 class ClientFactory extends AbstractFactory
 {
+
+    /**
+     * @param ContainerInterface $container
+     * @param array|string|callable $callbackOptions
+     * @return CallbackChain
+     */
+    protected function buildCallbackChain(ContainerInterface $container, $callbackOptions)
+    {
+        $callbackChain = new CallbackChain();
+
+        if (null === $callbackOptions) {
+            return $callbackChain;
+        }
+
+        if (is_callable($callbackOptions) || !is_array($callbackOptions)) {
+            $callbackOptions = [$callbackOptions];
+        }
+
+        foreach ($callbackOptions as $callbackItem) {
+            if (is_string($callbackItem)) {
+                $callbackItem = $container->get($callbackItem);
+            }
+
+            $callbackChain->addCallback($callbackItem);
+        }
+
+        return $callbackChain;
+    }
+
     /**
      * @param ContainerInterface $container
      * @param string             $requestedName
@@ -32,6 +62,22 @@ class ClientFactory extends AbstractFactory
 
         if (!array_key_exists('processors', $ravenOptions)) {
             $ravenOptions['processors'] = [SanitizeDataProcessor::class];
+        }
+
+        if (!array_key_exists('logger', $ravenOptions)) {
+            $ravenOptions['logger'] = 'SentryModule';
+        }
+
+        if (array_key_exists('send_callback', $ravenOptions)) {
+            $ravenOptions['send_callback'] = $this->buildCallbackChain($container, $ravenOptions['send_callback']);
+        }
+
+        if (array_key_exists('transport', $ravenOptions)) {
+            $transport = $ravenOptions['transport'];
+            if (is_string($transport)) {
+                $transport = $container->get($transport);
+            }
+            $ravenOptions['transport'] = $transport;
         }
 
         $ravenClient = new \Raven_Client($options->getDsn(), $ravenOptions);

--- a/src/Service/ClientFactory.php
+++ b/src/Service/ClientFactory.php
@@ -13,10 +13,10 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  */
 class ClientFactory extends AbstractFactory
 {
-
     /**
-     * @param ContainerInterface $container
+     * @param ContainerInterface    $container
      * @param array|string|callable $callbackOptions
+     *
      * @return CallbackChain
      */
     protected function buildCallbackChain(ContainerInterface $container, $callbackOptions)

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facile\SentryModule\Transport;
+
+interface TransportInterface
+{
+    /**
+     * @param \Raven_Client $client
+     * @param array $data
+     */
+    public function __invoke(\Raven_Client $client, array $data);
+}

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -6,7 +6,7 @@ interface TransportInterface
 {
     /**
      * @param \Raven_Client $client
-     * @param array $data
+     * @param array         $data
      */
     public function __invoke(\Raven_Client $client, array $data);
 }


### PR DESCRIPTION
### Added
- Log Writer: Added Monolog namespace to default excluded function calls on backtrace
- Log Writer: Added the possibility to add other namespaces to excluded function calls on backtrace
- Added the possibility to add multiple `send_callback`s and retrieving it from container
- Added `CallbackInterface`
- Added the possibility to specify the `transport` via service name, retrieving it from container  
- Added `TransportInterface`
### Changed
- Changed default logger name to `SentryModule`
- Required minimum version 1.4 of sentry library
