### PR TITLE
Implements configuration setting to allow disabling of the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To configure an instance of the client you can do as below:
 
 return [
     'sentry' => [
+        'disable_module' => false,
         'options' => [
             'dsn' => '',
             // other sentry options

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -18,6 +18,7 @@ final class ConfigProvider
         return [
             'dependencies' => $this->getDependencies(),
             'sentry' => [
+                'disable_module' => false,
                 'options' => [
                     'dsn' => '',
                 ],

--- a/src/Module.php
+++ b/src/Module.php
@@ -29,11 +29,16 @@ final class Module
         $application = $e->getApplication();
         $container = $application->getServiceManager();
 
+        /** @var array<string, mixed> $appConfig */
+        $appConfig = $container->get('config');
+
+        if (($appConfig['sentry']['disable_module'] ?? false)) {
+            return;
+        }
+
         // Get the Hub to initialize it
         $container->get(HubInterface::class);
 
-        /** @var array<string, mixed> $appConfig */
-        $appConfig = $container->get('config');
         $config = $appConfig['sentry']['javascript'] ?? [];
         $options = $config['options'] ?? [];
 

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -23,6 +23,31 @@ class ModuleTest extends TestCase
         $this->assertArrayNotHasKey('dependencies', $module->getConfig());
     }
 
+    public function testOnBootstrapWithDisableModule(): void
+    {
+        $event = $this->prophesize(MvcEvent::class);
+        $application = $this->prophesize(Application::class);
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $event->getApplication()->willReturn($application->reveal());
+        $application->getServiceManager()->willReturn($container->reveal());
+        $container->get(HubInterface::class)->shouldNotBeCalled();
+        $container->get('ViewHelperManager')->shouldNotBeCalled();
+        $container->get('HeadScript')->shouldNotBeCalled();
+        $container->get('config')->willReturn([
+            'sentry' => [
+                'disable_module' => true,
+                'options' => [],
+                'javascript' => [
+                    'inject_script' => false,
+                ],
+            ],
+        ]);
+
+        $module = new Module();
+        $module->onBootstrap($event->reveal());
+    }
+
     public function testOnBootstrapWithDisableJS(): void
     {
         $event = $this->prophesize(MvcEvent::class);
@@ -37,6 +62,7 @@ class ModuleTest extends TestCase
         $container->get('HeadScript')->shouldNotBeCalled();
         $container->get('config')->willReturn([
             'sentry' => [
+                'disable_module' => false,
                 'options' => [],
                 'javascript' => [
                     'inject_script' => false,


### PR DESCRIPTION
Adds configuration support for boolean `disable_module` setting which allows to control the module bootstrap.

Use case scenario: in multiple environments need to disable the module for one environment. Having this configuration setting you would be able to disable sentry module when provisioning the application for the specific environment.